### PR TITLE
Update for @font-face mixin in helpers/fonts

### DIFF
--- a/src/_helpers/_fonts.scss
+++ b/src/_helpers/_fonts.scss
@@ -11,11 +11,11 @@
 @mixin font-face($name, $url) {
   @font-face {
     font-family: #{$name};
-    src: url('#{$url}.eot');
-    src: url('#{$url}.eot#iefix') format("embedded-opentype"),
-         url('#{$url}.ttf') format('ttf'),
-         url('#{$url}.svg##{$name}') format('svg'),
-         url('#{$url}.woff') format('woff');
+    src: url('#{$url}.eot#') format('embedded-opentype'),
+         url('#{$url}.woff2') format('woff2'),
+         url('#{$url}.woff') format('woff'),
+         url('#{$url}.ttf') format('truetype'),
+         url('#{$url}.svg##{$name}') format('svg');
 
     @content;
   }


### PR DESCRIPTION
Changes:
- Added WOFF2 format
- Removed duplicate EOT file URL since there are no benefits in IE <= 8
- Used shorter IE fix (limited to fragment identifier only)
- Ordered font file URLs by preferred formats