### PR TITLE
Sache support & updated metadata in manifests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,5 @@ bower.json
 Gemfile
 Gemfile.lock
 Gruntfile.js
+sache.json
 src/

--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "Gruntfile.js",
     "node_modules/",
     "package.json",
+    "sache.json",
     "src/"
   ],
   "keywords": [

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     }
   ],
   "dependencies": {},
-  "description": "Much helpers for the developmentment with scss.",
+  "description": "A collection of many helpers to improve your workflow in SCSS",
   "devDependencies": {},
   "homepage": "https://github.com/scss-components/scss-components",
   "ignore": [

--- a/bower.json
+++ b/bower.json
@@ -22,10 +22,15 @@
     "src/"
   ],
   "keywords": [
-    "scss",
+    "collection",
+    "components",
+    "frontend",
     "helpers",
     "library",
-    "frontend"
+    "sass",
+    "scss",
+    "standards",
+    "tools"
   ],
   "license": "MIT",
   "main": "dist/components.scss",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "url": "https://christiangrete.com"
     }
   ],
-  "description": "Much helpers for the development with scss.",
+  "description": "A collection of many helpers to improve your workflow in SCSS",
   "dependencies": {},
   "devDependencies": {
     "bower": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,15 @@
   ],
   "homepage": "https://github.com/scss-components/scss-components",
   "keywords": [
-    "scss",
+    "collection",
+    "components",
+    "frontend",
     "helpers",
     "library",
-    "frontend"
+    "sass",
+    "scss",
+    "standards",
+    "tools"
   ],
   "license": "MIT",
   "main": "dist/components.scss",

--- a/sache.json
+++ b/sache.json
@@ -1,0 +1,15 @@
+{
+  "name": "scss-components",
+  "description": "A collection of many helpers to improve your workflow in SCSS",
+  "tags": [
+    "collection",
+    "components",
+    "frontend",
+    "helpers",
+    "library",
+    "sass",
+    "scss",
+    "standards",
+    "tools"
+  ]
+}


### PR DESCRIPTION
Changes:
- Added `sache.json` manifest file to support listing on [Sache](https://www.sache.in)
- Reordered and extended keywords in manifest files
- Reworded description property (fixed grammatical issues)
- Fetched upstream and merged (didn’t harm anything, can be ignored)

Edit:
- Excluded `sache.json` file from publishing